### PR TITLE
Fix nil change dictionary bug

### DIFF
--- a/Sources/UserDefault/UserDefault.swift
+++ b/Sources/UserDefault/UserDefault.swift
@@ -299,7 +299,8 @@ extension UserDefault {
             guard
                 keyPath == self.key.rawValue,
                 object as? UserDefaults == self.store,
-                let value = change?[.newKey] as? Value
+                let change = change,
+                let value = change[.newKey] as? Value
             else { return }
             
             self.subject.send(value)


### PR DESCRIPTION
If Value is an optional type, optional chaining off of the change
dictionary would send a nil value to the publisher even if the stored
value is not actually nil.